### PR TITLE
Fix the caching condition in both files configure and configure.ac

### DIFF
--- a/configure
+++ b/configure
@@ -5298,10 +5298,10 @@ if test "x$cross_compiling" = "xyes"; then
     *)	echo "configure: cross-compiling for $host is not supported" >&2
 	;;
     esac
-#    if test -n "${cross_cache}" && test -r "${cross_cache}"; then
-#	echo "loading cross-build cache file ${cross_cache}"
-#	. ${cross_cache}
-#    fi
+    if false && test -n "${cross_cache}" && test -r "${cross_cache}"; then
+	echo "loading cross-build cache file ${cross_cache}"
+	. ${cross_cache}
+    fi
     unset cross_cache
     SIGNAMES_O='signames.o'
     CROSS_COMPILE='-DCROSS_COMPILING'

--- a/configure.ac
+++ b/configure.ac
@@ -474,7 +474,7 @@ if test "x$cross_compiling" = "xyes"; then
     *)	echo "configure: cross-compiling for $host is not supported" >&2
 	;;
     esac
-    if test -n "${cross_cache}" && test -r "${cross_cache}"; then
+    if false && test -n "${cross_cache}" && test -r "${cross_cache}"; then
 	echo "loading cross-build cache file ${cross_cache}"
 	. ${cross_cache}
     fi


### PR DESCRIPTION
In some cases, configure is regenerated, most likely because the default runners might have different autoconf versions. 